### PR TITLE
incorrect table names in setup_ddb.sh

### DIFF
--- a/setup_ddb.sh
+++ b/setup_ddb.sh
@@ -2,6 +2,6 @@
 
 # Uses the AWS CLI and to create tables for votebot
 
-aws dynamodb create-table --table-name vote-options2 --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 --key-schema AttributeName=selection,KeyType=HASH --attribute-definitions AttributeName=selection,AttributeType=S
+aws dynamodb create-table --table-name vote-options --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 --key-schema AttributeName=selection,KeyType=HASH --attribute-definitions AttributeName=selection,AttributeType=S
 
-aws dynamodb create-table --table-name vote-open2 --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 --key-schema AttributeName=vote,KeyType=HASH --attribute-definitions AttributeName=vote,AttributeType=S
+aws dynamodb create-table --table-name vote-open --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 --key-schema AttributeName=vote,KeyType=HASH --attribute-definitions AttributeName=vote,AttributeType=S


### PR DESCRIPTION
table names in setup_ddb.ssh (incorrectly, I believe) create:

```
vote-open2
vote-options2
```

instead of:

```
vote-open
vote-options
```
